### PR TITLE
Fix mistaken CQL command

### DIFF
--- a/instructions/step-1.md
+++ b/instructions/step-1.md
@@ -187,7 +187,7 @@ UPDATE imdb.movies SET genres = genres + {'Polar'} WHERE title = 'Pulp Fiction';
 Vous pouvez supprimer les données de la manière suivante :
 
 ```sql
-DELETE from imdb.movies;
+TRUNCATE imdb.movies;
 ```
 
 Ou avec une condition :

--- a/instructions/step-1.md
+++ b/instructions/step-1.md
@@ -261,7 +261,7 @@ Qu'optenez-vous lorsque vous exécutez la requête suivante ?
 SELECT * FROM imdb.movies_by_title WHERE title = '12 Angry Men';
 ```
 
-Comment modéliser vos données pour pouvoir servir la requête suivnate ?
+Comment modéliser vos données pour pouvoir servir la requête suivante ?
 
 ```sql
 SELECT * FROM imdb.movies WHERE rank = 1;


### PR DESCRIPTION
`DELETE FROM` command cannot be used without a condition `WHERE xxx`